### PR TITLE
Preserve previous TRV schedule names

### DIFF
--- a/ShellyMQTT.indigoPlugin/Contents/Info.plist
+++ b/ShellyMQTT.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/ShellyMQTT.indigoPlugin/Contents/Server Plugin/Devices/Shelly_TRV.py
+++ b/ShellyMQTT.indigoPlugin/Contents/Server Plugin/Devices/Shelly_TRV.py
@@ -117,7 +117,10 @@ class Shelly_TRV(Shelly):
         valve_position = thermostat.get("pos", None)
         schedule = thermostat.get("schedule", False)
         schedule_profile = thermostat.get("schedule_profile")
-        self.schedule_profile_names = thermostat.get("schedule_profile_names", [])
+        schedule_profile_names = thermostat.get("schedule_profile_names", None)
+
+        if schedule_profile_names is not None:
+            self.schedule_profile_names = schedule_profile_names
 
         if target_temperature is not None:
             if self.device.pluginProps.get("temp-units", "C") == "F":

--- a/ShellyMQTT.indigoPlugin/Contents/Server Plugin/Devices/tests/test_Shelly_TRV.py
+++ b/ShellyMQTT.indigoPlugin/Contents/Server Plugin/Devices/tests/test_Shelly_TRV.py
@@ -185,6 +185,11 @@ class Test_Shelly_TRV(unittest.TestCase):
         }
         self.assertEqual(expected, self.shelly.get_schedule_profiles())
 
+    def test_trv_does_not_clear_missing_schedule_profiles(self):
+        self.shelly.schedule_profile_names = ["A", "B", "C", "D", "E"]
+        self.shelly.handleMessage("shellies/trv/settings", '{"thermostats": [{}]}')
+        self.assertEqual(["A", "B", "C", "D", "E"], self.shelly.schedule_profile_names)
+
     def test_trv_default_schedule_profile_names(self):
         expected = {
             1: None,


### PR DESCRIPTION
Closes #140

MQTT messages without thermostat schedule names no longer clear the internal state tracking the schedule names. The schedule names will only be cleared if an empty list is sent from the device.